### PR TITLE
Add the Drosophila Anatomy Ontology.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - NCIt OBO Edition (NCIT)
   - Plant Ontology (PO)
   - Plant Phenology Ontology (PPO)
+  - Drosophila Anatomy Ontology (FBbt)
 - Precomputed OWL classification (class hierarchy)
 - Materialized “class relations” from existential property restrictions (in separate named graphs)
 - Blazegraph RDF triplestore; SPARQL query interface

--- a/ontologies.txt
+++ b/ontologies.txt
@@ -21,3 +21,6 @@ http://purl.obolibrary.org/obo/go/extensions/go-bfo-bridge.owl
 http://purl.obolibrary.org/obo/ncbitaxon.owl
 https://github.com/EBISPOT/efo/releases/download/current/efo-base.owl
 http://purl.obolibrary.org/obo/pcl/pcl-base.owl
+http://purl.obolibrary.org/obo/fbbt/fbbt-base.owl
+http://purl.obolibrary.org/obo/uberon/bridge/uberon-bridge-to-fbbt.owl
+http://purl.obolibrary.org/obo/uberon/bridge/cl-bridge-to-fbbt.owl


### PR DESCRIPTION
This PR adds the Drosophila Anatomy Ontology (DAO, aka FBbt) and the corresponding bridges with Uberon and CL, as wanted by @dosumis.

(Beware that given the memory requirements, I have not been able to build ubergraph locally, so I can’t guarantee this doesn’t break anything…)