### PR TITLE
Create cell_by_type_location_species.rq

### DIFF
--- a/sparql/cell_by_type_location_species.rq
+++ b/sparql/cell_by_type_location_species.rq
@@ -1,0 +1,19 @@
+#+ description: Enter an anatomical location, get back a list of cell type IRIs and labels
+
+#+ defaults:
+#+   - location: http://purl.obolibrary.org/obo/UBERON_0002113
+#+   - cell: http://purl.obolibrary.org/obo/CL_0000000
+#+   - taxon: http://purl.obolibrary.org/obo/NCBITaxon_33208
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX overlaps: <http://purl.obolibrary.org/obo/RO_0002131>
+PREFIX in_taxon: <http://purl.obolibrary.org/obo/RO_0002162>
+
+SELECT DISTINCT ?cell_iri (STR(?qlabel) as ?cell_label)
+WHERE {
+   ?cell_iri overlaps: ?_location_iri .
+   ?cell_iri rdfs:subClassOf ?_cell_iri .
+   ?cell_iri in_taxon: ?_taxon_iri
+   ?cell_iri rdfs:label ?qlabel .
+  }

--- a/sparql/cell_by_type_location_species.rq
+++ b/sparql/cell_by_type_location_species.rq
@@ -14,6 +14,6 @@ SELECT DISTINCT ?cell_iri (STR(?qlabel) as ?cell_label)
 WHERE {
    ?cell_iri overlaps: ?_location_iri .
    ?cell_iri rdfs:subClassOf ?_cell_iri .
-   ?cell_iri in_taxon: ?_taxon_iri
+   ?cell_iri in_taxon: ?_taxon_iri .
    ?cell_iri rdfs:label ?qlabel .
   }


### PR DESCRIPTION
The in taxon might be a bit strict.  It only gets terms that strictly apply to one species.  In future we may be able to use taxon slim tags for applicability more broadly.