### PR TITLE
Filter out problematic value from GO.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ ontologies-merged.ttl: mirror
 	$(ROBOT) merge $(addprefix -i mirror/,$(shell ls mirror)) \
 	remove --axioms 'disjoint' --trim true --preserve-structure false \
 	remove --term 'owl:Nothing' --trim true --preserve-structure false \
+	query --update build-sparql/filter-bad-uri-values.ru \
 	reason -r ELK -D debug.ofn -o $@.owl &&\
 	riot -q --nocheck --output=turtle $@.owl >$@
 

--- a/build-sparql/filter-bad-uri-values.ru
+++ b/build-sparql/filter-bad-uri-values.ru
@@ -1,0 +1,8 @@
+PREFIX term_tracker_item: <http://purl.obolibrary.org/obo/IAO_0000233>
+DELETE {
+  ?term term_tracker_item: ?value .
+}
+WHERE {
+  ?term term_tracker_item: ?value .
+  FILTER(!STRSTARTS(STR(?value), "http"))
+}


### PR DESCRIPTION
A malformed `anyURI` value is blocking a new Ubergraph build.